### PR TITLE
msm8953-common: Give proper permissions for /dev/diag

### DIFF
--- a/rootdir/ueventd.qcom.rc
+++ b/rootdir/ueventd.qcom.rc
@@ -31,7 +31,7 @@
 firmware_directories /vendor/firmware_mnt/image/
 
 # the DIAG device node is not world writable/readable.
-/dev/diag                 0660   system     oem_2901
+/dev/diag                 0666   system     oem_2901
 
 /dev/genlock              0666   system     system
 /dev/wlan                 0660   wifi       wifi


### PR DESCRIPTION
* This gives proper permission to /dev/diag node so that diag driver can load successfully

Before in log:
Diag_Lib:  Diag_LSM_Init: Failed to open handle to diag driver, error = 13

After in log:
Diag_Lib: qpLogDiagInit <== result : 1
Diag_Lib: QMID : gIsQXDMDisabled 0, gIsADBDisabled 1, gIsDebugDisabled 0, gIsIMSLogsDisabled 0